### PR TITLE
Fixed bug in I18nWidget decompress()

### DIFF
--- a/i18nfield/forms.py
+++ b/i18nfield/forms.py
@@ -47,8 +47,9 @@ class I18nWidget(forms.MultiWidget):
                 ) and lng in value.data
                 else None
             )
-            if not first_enabled and lng in self.enabled_locales:
-                first_enabled = i
+            if lng in self.enabled_locales:
+                if not first_enabled:
+                    first_enabled = i
                 if dataline:
                     any_enabled_filled = True
             data.append(dataline)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -204,3 +204,10 @@ def test_widget_decompress_all_enabled_missing():
     assert f.widget.decompress({'en': 'Hello'}) == [
         None, 'Hello', 'Hello'
     ]
+
+def test_widget_decompress_first_two_enabled_not_filled():
+    f = I18nFormField(widget=I18nTextInput, required=False)
+    f.widget.enabled_locales = ['de', 'en', 'fr']
+    assert f.widget.decompress({'fr': 'Bonjour'}) == [
+        None, None, 'Bonjour'
+    ]


### PR DESCRIPTION
If the first enabled locale appears before the first filled locale, any_enabled_filled will never get True and then the first enabled widget will be filled with value, even though it is not in the original LazyI18nString.

This commit fixes this by rearranging the conditionals slightly.