### PR TITLE
Be more safe about value retrieval

### DIFF
--- a/i18nfield/forms.py
+++ b/i18nfield/forms.py
@@ -141,7 +141,7 @@ class I18nFormField(forms.MultiValueField):
         for i, field in enumerate(self.fields):
             try:
                 field_value = value[i]
-            except IndexError:
+            except (IndexError, TypeError):
                 field_value = None
             if field_value not in self.empty_values:
                 found = True


### PR DESCRIPTION
A user managed to trigger this in a modelform in a modelview without any interference on our part. Not sure how this value got to be ``None``, but it would be nice not to barf.