### PR TITLE
Add class to remove flags in single-language widgets

### DIFF
--- a/docs/strings.rst
+++ b/docs/strings.rst
@@ -103,6 +103,6 @@ values for internationalized form fields in the codebase.
 
 .. doctest::
 
-   >>> from django.utils.translation import ugettext_noop
-   >>> LazyI18nString.from_gettext(ugettext_noop('Hello'))
+   >>> from django.utils.translation import gettext_noop
+   >>> LazyI18nString.from_gettext(gettext_noop('Hello'))
    <LazyI18nString: <LazyGettextProxy: 'Hello'>>

--- a/i18nfield/forms.py
+++ b/i18nfield/forms.py
@@ -86,7 +86,10 @@ class I18nWidget(forms.MultiWidget):
         return mark_safe(self.format_output(output))
 
     def format_output(self, rendered_widgets) -> str:
-        return '<div class="i18n-form-group">%s</div>' % ''.join(rendered_widgets)
+        return '<div class="i18n-form-group%s">%s</div>' % (
+            ' i18n-form-single-language' if len(rendered_widgets) <= 1 else '',
+            ''.join(rendered_widgets),
+        )
 
 
 class I18nTextInput(I18nWidget):

--- a/i18nfield/rest_framework.py
+++ b/i18nfield/rest_framework.py
@@ -1,4 +1,8 @@
 from django.conf import settings
+
+from .fields import I18nCharField, I18nTextField
+from .strings import LazyI18nString
+
 try:
     from rest_framework.exceptions import ValidationError
     from rest_framework.fields import Field
@@ -7,9 +11,6 @@ try:
     from rest_framework.utils.encoders import JSONEncoder
 except ImportError:
     ValidationError = Field = ModelSerializer = JSONRenderer = JSONEncoder = object
-
-from .fields import I18nCharField, I18nTextField
-from .strings import LazyI18nString
 
 
 class I18nRestFrameworkEncoder(JSONEncoder):

--- a/i18nfield/strings.py
+++ b/i18nfield/strings.py
@@ -1,9 +1,9 @@
 import json
-from typing import Dict, Optional, Union, Iterable
+from typing import Dict, Optional, Union
 
 from django.conf import settings
 from django.utils import translation
-from django.utils.translation import override, gettext
+from django.utils.translation import gettext, override
 
 
 class LazyI18nString:
@@ -62,7 +62,10 @@ class LazyI18nString:
 
         if isinstance(self.data, dict):
             firstpart = lng.split('-')[0]
-            similar = [l for l in self.data.keys() if (l.startswith(firstpart + "-") or firstpart == l) and l != lng]
+            similar = [
+                loc for loc in self.data.keys()
+                if (loc.startswith(firstpart + "-") or firstpart == loc) and loc != lng
+            ]
             if self.data.get(lng):
                 return self.data[lng]
             elif self.data.get(firstpart):
@@ -123,6 +126,6 @@ class LazyI18nString:
 
     @classmethod
     def from_gettext(cls, lazygettext) -> 'LazyI18nString':
-        l = LazyI18nString({})
-        l.data = cls.LazyGettextProxy(lazygettext)
-        return l
+        result = LazyI18nString({})
+        result.data = cls.LazyGettextProxy(lazygettext)
+        return result

--- a/i18nfield/strings.py
+++ b/i18nfield/strings.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Union, Iterable
 
 from django.conf import settings
 from django.utils import translation
-from django.utils.translation import override, ugettext
+from django.utils.translation import override, gettext
 
 
 class LazyI18nString:
@@ -110,13 +110,13 @@ class LazyI18nString:
 
         def __getitem__(self, item):
             with override(item):
-                return str(ugettext(self.lazygettext))
+                return str(gettext(self.lazygettext))
 
         def __contains__(self, item):
             return True
 
         def __str__(self):
-            return str(ugettext(self.lazygettext))
+            return str(gettext(self.lazygettext))
 
         def __repr__(self):  # NOQA
             return '<LazyGettextProxy: %s>' % repr(self.lazygettext)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 160
 exclude = migrations,.ropeproject,settings.py,conftest.py
-max-complexity = 11
+max-complexity = 12
 
 [isort]
 combine_as_imports = true

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,13 +1,11 @@
-from io import StringIO
-
-from lxml.html import html5parser
-
 import pytest
 from django.core.exceptions import ValidationError
 from django.forms import inlineformset_factory, modelformset_factory
+from lxml.html import html5parser
 
 from i18nfield.forms import (
-    I18nFormField, I18nInlineFormSet, I18nModelFormSet, I18nTextInput, I18nForm
+    I18nForm, I18nFormField, I18nInlineFormSet, I18nModelFormSet,
+    I18nTextInput,
 )
 from i18nfield.strings import LazyI18nString
 
@@ -204,6 +202,7 @@ def test_widget_decompress_all_enabled_missing():
     assert f.widget.decompress({'en': 'Hello'}) == [
         None, 'Hello', 'Hello'
     ]
+
 
 def test_widget_decompress_first_two_enabled_not_filled():
     f = I18nFormField(widget=I18nTextInput, required=False)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -3,8 +3,8 @@ import json
 import pytest
 from rest_framework.exceptions import ValidationError
 
-from i18nfield.strings import LazyI18nString
 from i18nfield.rest_framework import I18nField, I18nRestFrameworkEncoder
+from i18nfield.strings import LazyI18nString
 
 
 @pytest.mark.parametrize('string', (

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -1,5 +1,5 @@
 from django.utils import translation
-from django.utils.translation import ugettext_noop
+from django.utils.translation import gettext_noop
 
 from i18nfield.strings import LazyI18nString
 
@@ -125,7 +125,7 @@ def test_equality():
 
 
 def test_from_gettext():
-    gstr = ugettext_noop('Welcome')
+    gstr = gettext_noop('Welcome')
     lstr = LazyI18nString.from_gettext(gstr)
     assert 'de' in lstr.data
     assert lstr.data['en'] == 'Welcome'

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -130,6 +130,7 @@ def test_from_gettext():
     assert 'de' in lstr.data
     assert lstr.data['en'] == 'Welcome'
 
+
 def test_map():
     data = {
         'de': 'hallo',

--- a/tox.ini
+++ b/tox.ini
@@ -44,4 +44,3 @@ deps=
 commands =
     flake8 i18nfield tests demoproject
     isort -c -rc flake8 i18nfield tests demoproject
-changedir = docs


### PR DESCRIPTION
This PR does three things:

- It removes some leftover references to **u**gettext (sorry, I missed them the first time)
- It adds a class to i18nfield widget groups that have only a single widget (re: #23)
- I noticed that the linters did not actually run, so I fixed the tox config and made sure the linters run and pass.

I can separate this into three PRs if you'd prefer, just let me know. As before, a release after the merge would be very appreciated.