### PR TITLE
Add method call for serialization

### DIFF
--- a/i18nfield/fields.py
+++ b/i18nfield/fields.py
@@ -42,6 +42,10 @@ class I18nFieldMixin:
         def from_db_value(self, value, expression, connection):
             return LazyI18nString(value)
 
+    def value_to_string(self, obj):
+        value = self.value_from_object(obj)
+        return self.get_prep_value(value)
+
     def formfield(self, **kwargs):
         defaults = {'form_class': self.form_class, 'widget': self.widget}
         defaults.update(kwargs)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -50,6 +50,7 @@ def test_serialization_json():
     # test that book survives being serialized
     old_book = Book.objects.get(pk=1)
     serialized_book = serializers.serialize("json", Book.objects.filter(pk=1))
+
     for book in serializers.deserialize("json", serialized_book):
         new_book = book.object
         break
@@ -89,3 +90,27 @@ def test_serialization_yaml():
         break
 
     assert old_book == new_book
+
+
+def test_initializing_with_string_only():
+    json = """
+[
+  {
+    "model": "testapp.book",
+    "pk": 1,
+    "fields": {
+      "title": "Der Herr der Ringe",
+      "abstract": "Frodo will einen Ring zerstören",
+      "author": 1
+    }
+  }
+]
+"""
+
+    for book in serializers.deserialize("json", json):
+        assert isinstance(book.object.title, LazyI18nString)
+        assert book.object.title.data == "Der Herr der Ringe"
+        assert isinstance(book.object.abstract, LazyI18nString)
+        assert book.object.abstract.data == "Frodo will einen Ring zerstören"
+
+        break

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core import serializers
 
 from i18nfield.fields import I18nFieldMixin
 from i18nfield.strings import LazyI18nString
@@ -37,3 +38,54 @@ def test_to_python():
     mx.to_python('A') == LazyI18nString('A')
     mx.to_python(LazyI18nString('A')) == LazyI18nString('A')
     mx.to_python(None) is None
+
+
+@pytest.mark.django_db
+def test_serialization_json():
+    a = Author.objects.create(name='Tolkien')
+    title = LazyI18nString({'de': 'Der Herr der Ringe', 'en': 'The Lord of the Rings'})
+    abstract = LazyI18nString({'de': 'Frodo will einen Ring zerstören', 'en': 'Frodo tries to destroy a ring'})
+    Book.objects.create(author=a, title=title, abstract=abstract)
+
+    # test that book survives being serialized
+    old_book = Book.objects.get(pk=1)
+    serialized_book = serializers.serialize("json", Book.objects.filter(pk=1))
+    for book in serializers.deserialize("json", serialized_book):
+        new_book = book.object
+        break
+
+    assert old_book == new_book
+
+
+@pytest.mark.django_db
+def test_serialization_xml():
+    a = Author.objects.create(name='Tolkien')
+    title = LazyI18nString({'de': 'Der Herr der Ringe', 'en': 'The Lord of the Rings'})
+    abstract = LazyI18nString({'de': 'Frodo will einen Ring zerstören', 'en': 'Frodo tries to destroy a ring'})
+    Book.objects.create(author=a, title=title, abstract=abstract)
+
+    # test that book survives being serialized
+    old_book = Book.objects.get(pk=1)
+    serialized_book = serializers.serialize("xml", Book.objects.filter(pk=1))
+    for book in serializers.deserialize("xml", serialized_book):
+        new_book = book.object
+        break
+
+    assert old_book == new_book
+
+
+@pytest.mark.django_db
+def test_serialization_yaml():
+    a = Author.objects.create(name='Tolkien')
+    title = LazyI18nString({'de': 'Der Herr der Ringe', 'en': 'The Lord of the Rings'})
+    abstract = LazyI18nString({'de': 'Frodo will einen Ring zerstören', 'en': 'Frodo tries to destroy a ring'})
+    Book.objects.create(author=a, title=title, abstract=abstract)
+
+    # test that book survives being serialized
+    old_book = Book.objects.get(pk=1)
+    serialized_book = serializers.serialize("yaml", Book.objects.filter(pk=1))
+    for book in serializers.deserialize("yaml", serialized_book):
+        new_book = book.object
+        break
+
+    assert old_book == new_book


### PR DESCRIPTION
Fixes #26

Django's internal serialization uses the `value_to_string()` method to serialize objects, which was not defined. 

This adds this method, in accordance with the [Django Documentation](https://docs.djangoproject.com/en/3.0/howto/custom-model-fields/#converting-field-data-for-serialization)

