### PR TITLE
install missing yaml dependency, fix tests

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,4 +10,4 @@ isort
 flake8
 lxml==4.3.*
 html5lib
-
+PyYAML


### PR DESCRIPTION
the tests fail because PyYaml is not installed:

```
    """
    YAML serializer.
    
    Requires PyYaml (https://pyyaml.org/), but that's checked for in __init__.
    """
    
    import collections
    import decimal
    from io import StringIO
    
>   import yaml
E   ModuleNotFoundError: No module named 'yaml'

.tox/py38-django22-sqlite/lib/python3.8/site-packages/django/core/serializers/pyyaml.py:11: ModuleNotFoundError
=== short test summary info ===
FAILED tests/test_fields.py::test_serialization_yaml - ModuleNotFoundError: No module named 'yaml'
```