### PR TITLE
remove unused "event" parameter in I18nFieldMixin

### DIFF
--- a/i18nfield/fields.py
+++ b/i18nfield/fields.py
@@ -12,10 +12,6 @@ class I18nFieldMixin:
     form_class = I18nFormField
     widget = I18nTextInput
 
-    def __init__(self, *args, **kwargs):
-        self.event = kwargs.pop('event', None)
-        super().__init__(*args, **kwargs)
-
     def to_python(self, value):
         if isinstance(value, LazyI18nString):
             return value


### PR DESCRIPTION
I18nFieldMixin (and therefore the Fields) has an unused `event` parameter. This PR removes it. I don't know, if any downstream projects rely on it, though. close at will :)