### PR TITLE
Adapt tox (and dependent) definitions for modern tools

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -390,4 +390,4 @@ epub_exclude_files = ['search.html']
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3/', None)}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ djangorestframework
 tox
 coverage
 codecov
+pytest-cov
 sphinx
 sphinx-autobuild
 isort

--- a/tox.ini
+++ b/tox.ini
@@ -1,44 +1,46 @@
 [tox]
 envlist =
-    py{36}-django32-sqlite
-    py{37,38,39,310}-django{32,40}-sqlite
+    py{39,310,311,312}-django42-sqlite
+    py{310,311,312,313}-django{51,52}-sqlite
     coverage
     doctest
     style
 
 [testenv]
-passenv = TOXENV CI TRAVIS TRAVIS_*
+passenv = TOXENV, CI, TRAVIS, TRAVIS_*
+allowlist_externals=make
 deps =
-    -Urrequirements_dev.txt
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
+    -r requirements_dev.txt
+    django42: Django>=4.2,<4.3
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
 commands = py.test tests
 
 [testenv:coverage]
-basepython=python3.10
+basepython=python3.13
 deps=
-    -Urrequirements_dev.txt
-    django==4.0.*
+    -r requirements_dev.txt
+    django==5.2.*
 commands =
     coverage erase
-    coverage run -m py.test tests
+    pytest --cov=i18nfield
     coverage report
     codecov -e TOXENV
 
 [testenv:doctest]
-basepython=python3.10
+basepython=python3.13
 deps=
-    -Urrequirements_dev.txt
-    django==4.0.*
+    -r requirements_dev.txt
+    django==5.2.*
 commands =
     make doctest
 changedir = docs
 
 [testenv:style]
-basepython=python3.10
+basepython=python3.13
 deps=
-    -Urrequirements_dev.txt
-    django==4.0.*
+    -r requirements_dev.txt
+    django==5.2.*
 commands =
     flake8 i18nfield tests demoproject
     isort -c -rc flake8 i18nfield tests demoproject


### PR DESCRIPTION
These changes seem to allow me to successfully run the tests with modern versions of Tox, Sphinx etc.
(also updating the range of Python and Django versions, of course)

This should probably be accompanied by some documentation corrections as well.

Refs #40 and #39